### PR TITLE
Make metadata/title consistent on Systems page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [ 'interscript/interscript' ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - uses: actions/checkout@master
+      - name: Install NPM dependencies
+        run: |
+          yarn install
+          yarn global add asciidoctor
+      - name: Build site
+        run: |
+          yarn adoc
+          yarn make

--- a/src/pages/systems.tsx
+++ b/src/pages/systems.tsx
@@ -80,12 +80,12 @@ const SystemList = () => {
     };
 
     const formatName = (name: string): string => {
-        const MAX_LENGTH = 50;
+        const MAX_LENGTH = 120;
         if (name.length >= MAX_LENGTH) {
             name = name.substring(0, MAX_LENGTH) + "...";
         }
 
-        return name.toUpperCase();
+        return name; //.toUpperCase();
     };
     const list: string[] = mapsInfo.data
         .sort()
@@ -103,10 +103,10 @@ const SystemList = () => {
             <dl key={system}>
               <dt>
                 <Link to={`/systems/${system}`} key={system}>
-                {`[${system}]`}
+                {<code>{system}</code>}
                 </Link>
-                {" "}({metaDataMap[system].sourceScript} {" to "}
-                  {metaDataMap[system].destinationScript})
+                {" "}(<code>{metaDataMap[system].sourceScript}</code> {" to "}
+                  <code>{metaDataMap[system].destinationScript}</code>)
               </dt>
               <dd>
                 <Link to={`/systems/${system}`} key={system}>

--- a/src/pages/systems.tsx
+++ b/src/pages/systems.tsx
@@ -79,6 +79,14 @@ const SystemList = () => {
         });
     };
 
+    const formatName = (name: string): string => {
+        const MAX_LENGTH = 50;
+        if (name.length >= MAX_LENGTH) {
+            name = name.substring(0, MAX_LENGTH) + "...";
+        }
+
+        return name.toUpperCase();
+    };
     const list: string[] = mapsInfo.data
         .sort()
         .filter((x: string) => {
@@ -95,14 +103,14 @@ const SystemList = () => {
             <dl key={system}>
               <dt>
                 <Link to={`/systems/${system}`} key={system}>
-                  {system}
+                {`[${system}]`}
                 </Link>
                 {" "}({metaDataMap[system].sourceScript} {" to "}
                   {metaDataMap[system].destinationScript})
               </dt>
               <dd>
                 <Link to={`/systems/${system}`} key={system}>
-                  {metaDataMap[system].name}
+                  {formatName(metaDataMap[system].name)}
                 </Link>
               </dd>
           </dl>


### PR DESCRIPTION
Fix #45 

Seeing BGN/PCGN series of systems, the following systems are in niether of romanization or transliteration or table of correspondences from their title.

```
Not compatible: BGN/PCGN 1962 System: [bgnpcgn-ell-Grek-Latn-1962]
Not compatible: Ministry of Culture and Tourism System (2000) BGN/PCGN 2011 Agreement: [bgnpcgn-kor-Kore-Latn-rok-2011]
Not compatible: BGN/PCGN 1981 System: [bgnpcgn-arm-Armn-Latn-1981]
Not compatible: BGN/PCGN German 2000 Roman-Script Spelling Convention Agreement: [bgnpcgn-deu-Latn-Latn-2000]
Not compatible: BGN/PCGN 1965 System: [bgnpcgn-ukr-Cyrl-Latn-1965]
Not compatible: BGN/PCGN 1956 System: [bgnpcgn-fas-Arab-Latn-1956]
Not compatible: BGN/PCGN 2019 Agreement: [bgnpcgn-ukr-Cyrl-Latn-2019]
Not compatible: BGN/PCGN Faroese 1968 Roman-Script Spelling Convention Agreement: [bgnpcgn-fao-Latn-Latn-1968]
Not compatible: Ministry of Culture and Tourism System (2000) BGN/PCGN 2011 Agreement: [bgnpcgn-kor-Hang-Latn-rok-2011]
Not compatible: BGN/PCGN Icelandic 1968 Roman-Script Spelling Convention Agreement: [bgnpcgn-isl-Latn-Latn-1968]
Not compatible: BGN/PCGN 1996 System: [bgnpcgn-ell-Grek-Latn-1996]
Not compatible: BGN/PCGN 1945 Agreement: [bgnpcgn-kor-Hang-Latn-kn-1945]
Not compatible: BGN/PCGN 1964 System: [bgnpcgn-mon-Cyrl-Latn-1964]
Not compatible: BGN/PCGN Northern Sami (North Lappish) 1984 Roman-Script Spelling Convention Agreement: [bgnpcgn-sme-Latn-Latn-1984]
Not compatible: CYRILLIC - ROMAN BGN/PCGN 2002 Agreement: [bgnpcgn-ron-cyrl-latn-2002]
Not compatible: BGN/PCGN 2013 Agreement: [bgnpcgn-bul-Cyrl-Latn-2013]
```
