### PR TITLE
Fix detect

### DIFF
--- a/src/pages/detect.tsx
+++ b/src/pages/detect.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { primaryColor } from "../App";
 import { Link } from "@reach/router";
 
-const API_URI = "https://api.interscript.org";
+const API_URI = "https://api.interscript.org/prod";
 
 interface SystemRelevance {
     distance: number;


### PR DESCRIPTION
The problem was introduced with 3a6d13ea84f220f7f55dcb97f580ca59c7c0c946. ab5899423c06202ba72fcde5040d6dacc3821bc9 fixed it for LiveDemo, but not for detect.