### PR TITLE
ci: clone interscript-ts main (port merged)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           cache: npm
       - name: Clone interscript-ts (file: dependency)
         run: |
-          git clone --depth=1 --branch feat/imf-runtime-ts https://github.com/interscript/interscript-ts.git ../interscript-ts
+          git clone --depth=1 --branch main https://github.com/interscript/interscript-ts.git ../interscript-ts
           cd ../interscript-ts && npm ci && npm run build
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           cache: npm
       - name: Clone interscript-ts (file: dependency)
         run: |
-          git clone --depth=1 --branch feat/imf-runtime-ts https://github.com/interscript/interscript-ts.git ../interscript-ts
+          git clone --depth=1 --branch main https://github.com/interscript/interscript-ts.git ../interscript-ts
           cd ../interscript-ts && npm ci && npm run build
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- the interscript-ts ISC runtime port landed on main (PR interscript/interscript-ts#35), so the CI sibling-clone step tracks main instead of the port branch

## Test plan
- [ ] build + deploy workflows green
