### PR TITLE
fix(ci): step-name colon made build/deploy workflows invalid YAML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-      - name: Clone interscript-ts (file: dependency)
+      - name: Clone interscript-ts (file dependency)
         run: |
           git clone --depth=1 --branch main https://github.com/interscript/interscript-ts.git ../interscript-ts
           cd ../interscript-ts && npm ci && npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-      - name: Clone interscript-ts (file: dependency)
+      - name: Clone interscript-ts (file dependency)
         run: |
           git clone --depth=1 --branch main https://github.com/interscript/interscript-ts.git ../interscript-ts
           cd ../interscript-ts && npm ci && npm run build


### PR DESCRIPTION
## Summary
- both site workflows were invalid YAML: the step name "Clone interscript-ts (file: dependency)" contains a colon+space, which is illegal inside a plain scalar
- consequence: build/deploy never ran anywhere (no PR checks, failed main pushes with 0 jobs) — the v2 cutover deploy on main has been failing since PR #119 merged
- rename to "(file dependency)"; workflows validate with a YAML parser

## Test plan
- [ ] build check appears and passes on this PR
- [ ] deploy runs green on main after merge
