### PR TITLE
fix(ci): serve dist/client on Pages (adapter nests static output)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: site
-          path: dist
+          path: dist/client

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: dist
+          path: dist/client
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- with the Node adapter present, astro emits dist/client (prerendered site) + dist/server (SSR chunks for the /api routes); uploading dist served a 404 at the domain root because index.html lives under client/
- upload dist/client so Pages serves the static site
- client-side API calls already target api.interscript.org; the same-origin /api examples in api-docs are the only loss (Pages is static-only)

## Test plan
- [ ] build green
- [ ] deploy green and https://interscript.org/ serves the v2 home
