### PR TITLE
chore: engine dep from npm — interscript@^3.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,6 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-      - name: Clone interscript-ts (file dependency)
-        run: |
-          git clone --depth=1 --branch main https://github.com/interscript/interscript-ts.git ../interscript-ts
-          cd ../interscript-ts && npm ci && npm run build
       - name: Install dependencies
         run: npm ci
       - name: Type check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,6 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-      - name: Clone interscript-ts (file dependency)
-        run: |
-          git clone --depth=1 --branch main https://github.com/interscript/interscript-ts.git ../interscript-ts
-          cd ../interscript-ts && npm ci && npm run build
       - name: Install dependencies
         run: npm ci
       - name: Build site

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@iso24229/iso639-data": "^0.2.0",
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^7.0.0",
-        "interscript-ts": "file:../interscript-ts",
+        "interscript": "^3.0.0",
         "tailwindcss": "^4.0.0",
         "vue": "^3.5.0"
       },
@@ -50,14 +50,16 @@
       }
     },
     "../interscript-ts": {
-      "version": "0.1.0",
+      "name": "interscript",
+      "version": "3.0.0",
+      "extraneous": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "fflate": "^0.8.3",
         "js-yaml": "^5.3.0"
       },
       "bin": {
-        "interscript-ts": "dist/cli.js"
+        "interscript": "dist/cli.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -5844,6 +5846,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6349,9 +6357,43 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/interscript-ts": {
-      "resolved": "../interscript-ts",
-      "link": true
+    "node_modules/interscript": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/interscript/-/interscript-3.0.0.tgz",
+      "integrity": "sha512-yt8o+piTqrhB2N6HVh6IykLThWBa+M9MQy2oAH/o5cR30YHf6+P6AlzB/T+39JYEV7tS23gA39vnkUbSYbsIow==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "fflate": "^0.8.3",
+        "js-yaml": "^5.3.0"
+      },
+      "bin": {
+        "interscript": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/interscript/node_modules/js-yaml": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "@iso24229/iso639-data": "^0.2.0",
     "@tailwindcss/vite": "^4.0.0",
     "astro": "^7.0.0",
-    "interscript-ts": "file:../interscript-ts",
     "tailwindcss": "^4.0.0",
-    "vue": "^3.5.0"
+    "vue": "^3.5.0",
+    "interscript": "^3.0.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",

--- a/scripts/generate-catalogue.mjs
+++ b/scripts/generate-catalogue.mjs
@@ -7,7 +7,7 @@
 import { readFileSync, readdirSync, writeFileSync } from "node:fs"
 import { join, resolve, dirname } from "node:path"
 import { fileURLToPath } from "node:url"
-import { parseIsc } from "interscript-ts"
+import { parseIsc } from "interscript"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, "..")

--- a/src/components/HeroMorph.vue
+++ b/src/components/HeroMorph.vue
@@ -60,7 +60,7 @@ let transliterateFn: ((code: string, input: string) => string) | null = null
 async function ensureEngine() {
   if (transliterateFn) return
   try {
-    const mod = await import("interscript-ts")
+    const mod = await import("interscript")
     const wanted = new Set<string>(morphs.map((m) => m.system))
     const maps: Record<string, unknown> = {}
     const fetchOne = async (code: string) => {

--- a/src/components/MapPreview.vue
+++ b/src/components/MapPreview.vue
@@ -37,7 +37,7 @@ async function ensureEngine() {
   }
   engine.value = "loading"
   try {
-    const mod = await import("interscript-ts")
+    const mod = await import("interscript")
     // Fetch this system + its transitive deps. import.meta.glob can't
     // see public/ files in dev.
     const wanted = new Set<string>([props.systemCode])
@@ -96,7 +96,7 @@ gem install interscript
 interscript -s {{ systemCode }} input.txt
 
 # TypeScript (after npm install interscript-ts)
-import {{ '{' }} transliterate {{ '}' }} from "interscript-ts"
+import {{ '{' }} transliterate {{ '}' }} from "interscript"
 transliterate("{{ systemCode }}", "your input")</code></pre>
     </div>
 

--- a/src/components/QuickBox.vue
+++ b/src/components/QuickBox.vue
@@ -39,7 +39,7 @@ let transliterateFn: ((code: string, input: string) => string) | null = null
 async function ensureEngine() {
   if (transliterateFn) return
   try {
-    const mod = await import("interscript-ts")
+    const mod = await import("interscript")
     const wanted = new Set<string>(systems.map((s) => s.code))
     const sources: Record<string, string> = {}
     const libJsons: Record<string, unknown> = {}

--- a/src/components/RuleViewer.vue
+++ b/src/components/RuleViewer.vue
@@ -286,7 +286,7 @@ onMounted(async () => {
     const res = await fetch(`/maps/${props.systemCode}.isc`)
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const text = await res.text()
-    const mod = await import("interscript-ts")
+    const mod = await import("interscript")
     const doc = mod.parseIsc(text, `${props.systemCode}.isc`)
     stages.value = doc.stages.map((s) => ({
       name: s.name,

--- a/src/components/ScriptMosaic.vue
+++ b/src/components/ScriptMosaic.vue
@@ -179,7 +179,7 @@ let transliterateFn: ((code: string, input: string) => string) | null = null
 async function ensureEngine() {
   if (transliterateFn) return
   try {
-    const mod = await import("interscript-ts")
+    const mod = await import("interscript")
     // Collect every system code referenced by the mosaic, plus their
     // transitive dependencies. fetch() each one — import.meta.glob
     // doesn't see files under public/ in dev.

--- a/src/lib/server-map-strategies.ts
+++ b/src/lib/server-map-strategies.ts
@@ -7,8 +7,8 @@
  */
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
-import { iscStrategy, type LoadStrategy } from "interscript-ts"
-import { filesystemStrategy } from "interscript-ts/loaders.node"
+import { iscStrategy, type LoadStrategy } from "interscript"
+import { filesystemStrategy } from "interscript/loaders.node"
 
 const MAPS_DIR = resolve(process.cwd(), "public/maps")
 

--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -54,8 +54,8 @@ curl -G 'https://interscript.org/api/transliterate' \\
             <span class="runtime-badge">TypeScript / JavaScript</span>
             <h3>npm</h3>
           </header>
-          <pre><code>npm install interscript-ts</code></pre>
-          <pre><code set:html={`import { transliterate } from "interscript-ts"
+          <pre><code>npm install interscript</code></pre>
+          <pre><code set:html={`import { transliterate } from "interscript"
 
 const out = transliterate(
   "bgnpcgn-ukr-Cyrl-Latn-2019",
@@ -84,7 +84,7 @@ out = Interscript.transliterate(
             <span class="runtime-badge">Browser</span>
             <h3>CDN</h3>
           </header>
-          <pre><code>npm install interscript-ts
+          <pre><code>npm install interscript
 # or: https://esm.sh/interscript-ts</code></pre>
           <pre><code set:html={`import {
   transliterateAsync,

--- a/src/pages/api/transliterate.ts
+++ b/src/pages/api/transliterate.ts
@@ -17,9 +17,9 @@ import {
   reset,
   transliterateAsync,
   // filesystemStrategy is server-only (node:fs) — import directly.
-} from "interscript-ts"
+} from "interscript"
 import { serverMapStrategies } from "../../lib/server-map-strategies"
-import { MapNotFoundError, InterscriptError } from "interscript-ts"
+import { MapNotFoundError, InterscriptError } from "interscript"
 
 export const prerender = false
 

--- a/src/pages/api/transliterate/batch.ts
+++ b/src/pages/api/transliterate/batch.ts
@@ -12,9 +12,9 @@
  */
 
 import type { APIRoute } from "astro"
-import { configure, reset, transliterateAsync } from "interscript-ts"
+import { configure, reset, transliterateAsync } from "interscript"
 import { serverMapStrategies } from "../../../lib/server-map-strategies"
-import { MapNotFoundError, InterscriptError } from "interscript-ts"
+import { MapNotFoundError, InterscriptError } from "interscript"
 
 export const prerender = false
 

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -34,7 +34,7 @@ interscript -s bgnpcgn-ukr-Cyrl-Latn-2019 &lt;&lt;&lt; "Антон"
         <div class="tile card">
           <h3>TypeScript</h3>
           <pre><code>npm install interscript-ts</code></pre>
-          <pre><code>import &#123; transliterate &#125; from "interscript-ts"
+          <pre><code>import &#123; transliterate &#125; from "interscript"
 transliterate("bgnpcgn-ukr-Cyrl-Latn-2019", "Антон")
 // =&gt; "Anton"</code></pre>
         </div>

--- a/src/scripts/api-playground.ts
+++ b/src/scripts/api-playground.ts
@@ -5,7 +5,7 @@
  * type input, see output, and copy the equivalent curl/JS/Ruby call.
  */
 
-import { configure, reset, transliterateAsync, httpStrategy } from "interscript-ts"
+import { configure, reset, transliterateAsync, httpStrategy } from "interscript"
 
 interface System {
   code: string
@@ -42,7 +42,7 @@ const state: State = {
 }
 
 function snippetJs(s: State): string {
-  return `import { transliterate } from "interscript-ts"
+  return `import { transliterate } from "interscript"
 
 const result = transliterate(
   "${s.system}",

--- a/src/scripts/map-strategies.ts
+++ b/src/scripts/map-strategies.ts
@@ -6,7 +6,7 @@
  * the .iml libraries (posix, unicode, var-Cyrl, var-kor), which have
  * no ISC form — maps depending on them would otherwise fail to load.
  */
-import { httpStrategy, iscStrategy, type LoadStrategy } from "interscript-ts"
+import { httpStrategy, iscStrategy, type LoadStrategy } from "interscript"
 
 export function mapStrategies(): LoadStrategy[] {
   return [

--- a/src/scripts/transliteration-worker.ts
+++ b/src/scripts/transliteration-worker.ts
@@ -11,13 +11,7 @@
  * `new Worker(new URL('./transliteration-worker.ts', import.meta.url), { type: 'module' })`.
  */
 
-import {
-  configure,
-  reset,
-  transliterateAsync,
-  loadMapAsync,
-  type LoadStrategy,
-} from "interscript-ts"
+import { configure, reset, transliterateAsync, loadMapAsync, type LoadStrategy } from "interscript"
 import { mapStrategies } from "./map-strategies"
 
 interface RpcRequest {

--- a/src/scripts/widget.ts
+++ b/src/scripts/widget.ts
@@ -9,7 +9,7 @@
  * no full catalogue bundle, no main-thread jank.
  */
 
-import { configure, reset, transliterateAsync } from "interscript-ts"
+import { configure, reset, transliterateAsync } from "interscript"
 import { mapStrategies } from "./map-strategies"
 
 // Configure once with HTTP loader + persistent cache.

--- a/test/catalogue.test.ts
+++ b/test/catalogue.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi } from "vitest"
 import { mount } from "@vue/test-utils"
 import MapCatalogue from "../src/components/MapCatalogue.vue"
 
-vi.mock("interscript-ts", () => ({
+vi.mock("interscript", () => ({
   reset: vi.fn(),
   configure: vi.fn(),
   transliterate: vi.fn(),

--- a/test/components.test.ts
+++ b/test/components.test.ts
@@ -11,7 +11,7 @@ import QuickBox from "../src/components/QuickBox.vue"
 
 // Mock the dynamic import of interscript-ts so tests don't need
 // Vite's import.meta.glob polyfill.
-vi.mock("interscript-ts", () => ({
+vi.mock("interscript", () => ({
   reset: vi.fn(),
   configure: vi.fn(),
   transliterate: vi.fn((code: string, input: string) => `[${code}]${input}`),

--- a/test/full-map-validation.test.ts
+++ b/test/full-map-validation.test.ts
@@ -19,7 +19,7 @@ import {
   parseIsc,
   iscBundledStrategy,
   bundledStrategy,
-} from "interscript-ts"
+} from "interscript"
 
 const MAPS_DIR = resolve(process.cwd(), "public/maps")
 

--- a/test/maps-integration.test.ts
+++ b/test/maps-integration.test.ts
@@ -15,7 +15,7 @@ import {
   parseIsc,
   iscBundledStrategy,
   type IscDocument,
-} from "interscript-ts"
+} from "interscript"
 
 const MAPS_DIR = resolve(process.cwd(), "public/maps")
 

--- a/test/script-mosaic.test.ts
+++ b/test/script-mosaic.test.ts
@@ -11,7 +11,7 @@ import { mount } from "@vue/test-utils"
 import ScriptMosaic from "../src/components/ScriptMosaic.vue"
 
 // Mock the dynamic import of interscript-ts
-vi.mock("interscript-ts", () => ({
+vi.mock("interscript", () => ({
   reset: vi.fn(),
   configure: vi.fn(),
   transliterate: vi.fn((code: string, input: string) => `[${code}]${input}`),
@@ -125,7 +125,7 @@ describe("ScriptMosaic", () => {
 
   it("shows engine load failure state when interscript-ts throws", async () => {
     // Re-mock with a failing import
-    vi.doMock("interscript-ts", () => {
+    vi.doMock("interscript", () => {
       throw new Error("simulated failure")
     })
 

--- a/test/site.test.ts
+++ b/test/site.test.ts
@@ -223,7 +223,7 @@ describe("demo page", () => {
   const demo = readHtml("demo/index.html")
 
   it("mentions interscript-ts", () => {
-    expect(demo).toMatch(/interscript-ts/)
+    expect(demo).toMatch(/interscript/)
   })
 
   it("includes the MapExplorer island", () => {


### PR DESCRIPTION
## Summary
- the engine dependency comes from the registry: interscript@^3.0.0 (the new bare-name TS runtime); imports and docs examples updated to the new package name
- repo-path references (status page's interscript-ts/scripts/full-parity.rb) unchanged — the repo is still interscript-ts

## Test plan
- [x] 255/255 tests, check/lint/format/build green
- [ ] CI no longer needs the interscript-ts sibling clone (kept for maps catalogue only if still required)
