### PR TITLE
chore: interscript ^4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@iso24229/iso639-data": "^0.2.0",
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^7.0.0",
-        "interscript": "^3.0.0",
+        "interscript": "^4.0.0",
         "tailwindcss": "^4.0.0",
         "vue": "^3.5.0"
       },
@@ -6358,9 +6358,9 @@
       "license": "ISC"
     },
     "node_modules/interscript": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/interscript/-/interscript-3.0.0.tgz",
-      "integrity": "sha512-yt8o+piTqrhB2N6HVh6IykLThWBa+M9MQy2oAH/o5cR30YHf6+P6AlzB/T+39JYEV7tS23gA39vnkUbSYbsIow==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/interscript/-/interscript-4.0.0.tgz",
+      "integrity": "sha512-FE6lzHPZTWZlVuuANdlnQirxbGIEgnu41c0RbPYyRl47Pr2Cze4oB5izGmF0dE+4znxTUUT5sc1E+0M7ScriKw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "astro": "^7.0.0",
     "tailwindcss": "^4.0.0",
     "vue": "^3.5.0",
-    "interscript": "^3.0.0"
+    "interscript": "^4.0.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",


### PR DESCRIPTION
Bumps the site runtime to the IMF-only 4.0.0 line. No site code
imports the removed manifest APIs (grep-verified), so this is a pure
dependency refresh: 239 vitest green, astro build clean.
