### PR TITLE
chore: interscript ^4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@iso24229/iso639-data": "^0.2.0",
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^7.0.0",
-        "interscript": "^4.0.0",
+        "interscript": "^4.1.0",
         "tailwindcss": "^4.0.0",
         "vue": "^3.5.0"
       },
@@ -6358,9 +6358,9 @@
       "license": "ISC"
     },
     "node_modules/interscript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/interscript/-/interscript-4.0.0.tgz",
-      "integrity": "sha512-FE6lzHPZTWZlVuuANdlnQirxbGIEgnu41c0RbPYyRl47Pr2Cze4oB5izGmF0dE+4znxTUUT5sc1E+0M7ScriKw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/interscript/-/interscript-4.1.0.tgz",
+      "integrity": "sha512-PO4G+Mledb2LXIdaEWC+pfkST2yZkdO3g0jBqs5i8LRVwDkjxRG2vxEmGexsKNaWX4VYAXJrS//1ApGebsjkBg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "astro": "^7.0.0",
     "tailwindcss": "^4.0.0",
     "vue": "^3.5.0",
-    "interscript": "^4.0.0"
+    "interscript": "^4.1.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",


### PR DESCRIPTION
Picks up the IMF registry's browser Cache API persistence — verified model zips download once per browser. 239 tests + build green.