### PR TITLE
feat(ml): ledger gains the Arabic 2.0 rungs

### DIFF
--- a/src/pages/ml.astro
+++ b/src/pages/ml.astro
@@ -3,6 +3,14 @@ import Base from "../layouts/Base.astro"
 
 const serverModels = [
   {
+    id: "ara-diac-2.0",
+    task: "diacritization",
+    pair: "Arabic → haraqat",
+    metric: "DER 2.29 · OOD WER 17.38",
+    artifact: "fp32 · 2.7 GiB · parts",
+    status: "releasing",
+  },
+  {
     id: "khm-latn-1.0",
     task: "translit",
     pair: "Khmer → Latin",
@@ -45,6 +53,14 @@ const serverModels = [
 ]
 
 const clientModels = [
+  {
+    id: "ara-diac-small-2.0",
+    task: "diacritization",
+    pair: "Arabic → haraqat",
+    metric: "DER 4.82 (1.0 was 8.26)",
+    artifact: "int8 · ~0.5 GiB",
+    status: "releasing",
+  },
   {
     id: "tha-g2p-small-1.0",
     task: "g2p",


### PR DESCRIPTION
## What

The neural-layer ledger gains the two Arabic 2.0 rungs:

- **ara-diac-2.0** (server tier): DER 2.2864 full-set windowed zero-skip — the new canonical teacher (news-domain sweep over 1.0: ID −0.29pp, OOD WikiNews-2024 multi-ref 17.3794/11.8273 vs 19.82/12.46). Best dedicated model on SadeedDiac-25 under the protocol.
- **ara-diac-small-2.0** (client tier): DER 4.8218 — a 42% error reduction over the 1.0 (8.259) at identical architecture and artifact size: r7 teacher labels + the Muon optimizer, pre-registered as E4 (gate ≤6.26, prediction 4.3–5.0).

Status "releasing" — artifacts gated and publishing via the release pipeline.
